### PR TITLE
--enable-werror is enabled by default when building gdb-7.6.1+ on OSX

### DIFF
--- a/Articles/How to configure golang develop environment with debug and unit test debug.md
+++ b/Articles/How to configure golang develop environment with debug and unit test debug.md
@@ -237,7 +237,7 @@ if you aleady installed,skipping this step.
 tar -zxvf gdb-*.tar.gz
 cd gdb-*
 export GOC_FOR_TARGET=<go compiler path,like:/usr/local/go>
-./configure --prefix=/usr
+./configure --prefix=/usr --disable-werror
 make -j8
 sudo make install
 	```


### PR DESCRIPTION
So for the build to succeed you need to add '--disable-werror' to the ./configure options
